### PR TITLE
fix the anchors for build tool listings

### DIFF
--- a/docs/query/typesafe.html
+++ b/docs/query/typesafe.html
@@ -348,17 +348,17 @@
   <div role="tabpanel">
 
     <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a href="#Maven1" aria-controls="Maven1" role="tab" data-toggle="tab">Maven</a></li>
-      <li role="presentation"><a href="#Ivy1" aria-controls="Ivy1" role="tab" data-toggle="tab">Ivy</a></li>
-      <li role="presentation"><a href="#Grape1" aria-controls="Grape1" role="tab" data-toggle="tab">Grape</a></li>
-      <li role="presentation"><a href="#Gradle1" aria-controls="Gradle1" role="tab" data-toggle="tab">Gradle</a></li>
-      <li role="presentation"><a href="#Buildr1" aria-controls="Buildr1" role="tab" data-toggle="tab">Buildr</a></li>
-      <li role="presentation"><a href="#SBT1" aria-controls="SBT1" role="tab" data-toggle="tab">SBT</a></li>
-      <li role="presentation"><a href="#Leiningen1" aria-controls="Leiningen1" role="tab" data-toggle="tab">Leiningen</a></li>
+      <li role="presentation" class="active"><a href="#Maven2" aria-controls="Maven2" role="tab" data-toggle="tab">Maven</a></li>
+      <li role="presentation"><a href="#Ivy2" aria-controls="Ivy2" role="tab" data-toggle="tab">Ivy</a></li>
+      <li role="presentation"><a href="#Grape2" aria-controls="Grape2" role="tab" data-toggle="tab">Grape</a></li>
+      <li role="presentation"><a href="#Gradle2" aria-controls="Gradle2" role="tab" data-toggle="tab">Gradle</a></li>
+      <li role="presentation"><a href="#Buildr2" aria-controls="Buildr2" role="tab" data-toggle="tab">Buildr</a></li>
+      <li role="presentation"><a href="#SBT2" aria-controls="SBT2" role="tab" data-toggle="tab">SBT</a></li>
+      <li role="presentation"><a href="#Leiningen2" aria-controls="Leiningen2" role="tab" data-toggle="tab">Leiningen</a></li>
     </ul>
 
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="Maven1">
+      <div role="tabpanel" class="tab-pane active" id="Maven2">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.avaje.ebean<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>ebean-querybean<span class="nt">&lt;/artifactId&gt;</span>
@@ -367,33 +367,33 @@
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Ivy1">
+      <div role="tabpanel" class="tab-pane" id="Ivy2">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency</span> <span class="na">org=</span><span class="s">&quot;org.avaje.ebean&quot;</span> <span class="na">name=</span><span class="s">&quot;ebean-querybean&quot;</span> <span class="na">rev=</span><span class="s">&quot;<span class='ebean-querybean-version'>${version}</span>&quot;</span><span class="nt">/&gt;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Grape1">
+      <div role="tabpanel" class="tab-pane" id="Grape2">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="nd">@Grapes</span><span class="o">(</span>
   <span class="nd">@Grab</span><span class="o">(</span><span class="n">group</span><span class="o">=</span><span class="s1">&#39;org.avaje.ebean&#39;</span><span class="o">,</span> <span class="n">module</span><span class="o">=</span><span class="s1">&#39;ebean-querybean&#39;</span><span class="o">,</span> <span class="n">version</span><span class="o">=</span><span class="s1">&#39;<span class='ebean-querybean-version'>${version}</span>&#39;</span><span class="o">)</span>
 <span class="o">)</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Gradle1">
+      <div role="tabpanel" class="tab-pane" id="Gradle2">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:ebean-querybean:<span class='ebean-querybean-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Buildr1">
+      <div role="tabpanel" class="tab-pane" id="Buildr2">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:ebean-querybean:<span class='ebean-querybean-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>    </div>
-      <div role="tabpanel" class="tab-pane" id="SBT1">
+      <div role="tabpanel" class="tab-pane" id="SBT2">
 <div class="syntax scala"><div class="highlight"><pre><span></span><span class="n">libraryDependencies</span> <span class="o">+=</span> <span class="s">&quot;org.avaje.ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;ebean-querybean&quot;</span> <span class="o">%</span> <span class="s">&quot;<span class='ebean-querybean-version'>${version}</span>&quot;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Leiningen1">
+      <div role="tabpanel" class="tab-pane" id="Leiningen2">
 <div class="syntax xml"><div class="highlight"><pre><span></span>[org.avaje.ebean/ebean-querybean &quot;<span class='ebean-querybean-version'>${version}</span>&quot;]
 </pre></div>
 </div>
@@ -510,17 +510,17 @@
   <div role="tabpanel">
 
     <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a href="#Maven1" aria-controls="Maven1" role="tab" data-toggle="tab">Maven</a></li>
-      <li role="presentation"><a href="#Ivy1" aria-controls="Ivy1" role="tab" data-toggle="tab">Ivy</a></li>
-      <li role="presentation"><a href="#Grape1" aria-controls="Grape1" role="tab" data-toggle="tab">Grape</a></li>
-      <li role="presentation"><a href="#Gradle1" aria-controls="Gradle1" role="tab" data-toggle="tab">Gradle</a></li>
-      <li role="presentation"><a href="#Buildr1" aria-controls="Buildr1" role="tab" data-toggle="tab">Buildr</a></li>
-      <li role="presentation"><a href="#SBT1" aria-controls="SBT1" role="tab" data-toggle="tab">SBT</a></li>
-      <li role="presentation"><a href="#Leiningen1" aria-controls="Leiningen1" role="tab" data-toggle="tab">Leiningen</a></li>
+      <li role="presentation" class="active"><a href="#Maven3" aria-controls="Maven3" role="tab" data-toggle="tab">Maven</a></li>
+      <li role="presentation"><a href="#Ivy3" aria-controls="Ivy3" role="tab" data-toggle="tab">Ivy</a></li>
+      <li role="presentation"><a href="#Grape3" aria-controls="Grape3" role="tab" data-toggle="tab">Grape</a></li>
+      <li role="presentation"><a href="#Gradle3" aria-controls="Gradle3" role="tab" data-toggle="tab">Gradle</a></li>
+      <li role="presentation"><a href="#Buildr3" aria-controls="Buildr3" role="tab" data-toggle="tab">Buildr</a></li>
+      <li role="presentation"><a href="#SBT3" aria-controls="SBT3" role="tab" data-toggle="tab">SBT</a></li>
+      <li role="presentation"><a href="#Leiningen3" aria-controls="Leiningen3" role="tab" data-toggle="tab">Leiningen</a></li>
     </ul>
 
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="Maven1">
+      <div role="tabpanel" class="tab-pane active" id="Maven3">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.avaje.ebean<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>querybean-agent<span class="nt">&lt;/artifactId&gt;</span>
@@ -529,33 +529,33 @@
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Ivy1">
+      <div role="tabpanel" class="tab-pane" id="Ivy3">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency</span> <span class="na">org=</span><span class="s">&quot;org.avaje.ebean&quot;</span> <span class="na">name=</span><span class="s">&quot;querybean-agent&quot;</span> <span class="na">rev=</span><span class="s">&quot;<span class='querybean-agent-version'>${version}</span>&quot;</span><span class="nt">/&gt;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Grape1">
+      <div role="tabpanel" class="tab-pane" id="Grape3">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="nd">@Grapes</span><span class="o">(</span>
   <span class="nd">@Grab</span><span class="o">(</span><span class="n">group</span><span class="o">=</span><span class="s1">&#39;org.avaje.ebean&#39;</span><span class="o">,</span> <span class="n">module</span><span class="o">=</span><span class="s1">&#39;querybean-agent&#39;</span><span class="o">,</span> <span class="n">version</span><span class="o">=</span><span class="s1">&#39;<span class='querybean-agent-version'>${version}</span>&#39;</span><span class="o">)</span>
 <span class="o">)</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Gradle1">
+      <div role="tabpanel" class="tab-pane" id="Gradle3">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:querybean-agent:<span class='querybean-agent-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Buildr1">
+      <div role="tabpanel" class="tab-pane" id="Buildr3">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:querybean-agent:<span class='querybean-agent-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>    </div>
-      <div role="tabpanel" class="tab-pane" id="SBT1">
+      <div role="tabpanel" class="tab-pane" id="SBT3">
 <div class="syntax scala"><div class="highlight"><pre><span></span><span class="n">libraryDependencies</span> <span class="o">+=</span> <span class="s">&quot;org.avaje.ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;querybean-agent&quot;</span> <span class="o">%</span> <span class="s">&quot;<span class='querybean-agent-version'>${version}</span>&quot;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Leiningen1">
+      <div role="tabpanel" class="tab-pane" id="Leiningen3">
 <div class="syntax xml"><div class="highlight"><pre><span></span>[org.avaje.ebean/querybean-agent &quot;<span class='querybean-agent-version'>${version}</span>&quot;]
 </pre></div>
 </div>
@@ -592,17 +592,17 @@
   <div role="tabpanel">
 
     <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a href="#Maven1" aria-controls="Maven1" role="tab" data-toggle="tab">Maven</a></li>
-      <li role="presentation"><a href="#Ivy1" aria-controls="Ivy1" role="tab" data-toggle="tab">Ivy</a></li>
-      <li role="presentation"><a href="#Grape1" aria-controls="Grape1" role="tab" data-toggle="tab">Grape</a></li>
-      <li role="presentation"><a href="#Gradle1" aria-controls="Gradle1" role="tab" data-toggle="tab">Gradle</a></li>
-      <li role="presentation"><a href="#Buildr1" aria-controls="Buildr1" role="tab" data-toggle="tab">Buildr</a></li>
-      <li role="presentation"><a href="#SBT1" aria-controls="SBT1" role="tab" data-toggle="tab">SBT</a></li>
-      <li role="presentation"><a href="#Leiningen1" aria-controls="Leiningen1" role="tab" data-toggle="tab">Leiningen</a></li>
+      <li role="presentation" class="active"><a href="#Maven4" aria-controls="Maven4" role="tab" data-toggle="tab">Maven</a></li>
+      <li role="presentation"><a href="#Ivy4" aria-controls="Ivy4" role="tab" data-toggle="tab">Ivy</a></li>
+      <li role="presentation"><a href="#Grape4" aria-controls="Grape4" role="tab" data-toggle="tab">Grape</a></li>
+      <li role="presentation"><a href="#Gradle4" aria-controls="Gradle4" role="tab" data-toggle="tab">Gradle</a></li>
+      <li role="presentation"><a href="#Buildr4" aria-controls="Buildr4" role="tab" data-toggle="tab">Buildr</a></li>
+      <li role="presentation"><a href="#SBT4" aria-controls="SBT4" role="tab" data-toggle="tab">SBT</a></li>
+      <li role="presentation"><a href="#Leiningen4" aria-controls="Leiningen4" role="tab" data-toggle="tab">Leiningen</a></li>
     </ul>
 
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="Maven1">
+      <div role="tabpanel" class="tab-pane active" id="Maven4">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.avaje.ebean<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>finder-generator<span class="nt">&lt;/artifactId&gt;</span>
@@ -611,33 +611,33 @@
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Ivy1">
+      <div role="tabpanel" class="tab-pane" id="Ivy4">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency</span> <span class="na">org=</span><span class="s">&quot;org.avaje.ebean&quot;</span> <span class="na">name=</span><span class="s">&quot;finder-generator&quot;</span> <span class="na">rev=</span><span class="s">&quot;<span class='finder-generator-version'>${version}</span>&quot;</span><span class="nt">/&gt;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Grape1">
+      <div role="tabpanel" class="tab-pane" id="Grape4">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="nd">@Grapes</span><span class="o">(</span>
   <span class="nd">@Grab</span><span class="o">(</span><span class="n">group</span><span class="o">=</span><span class="s1">&#39;org.avaje.ebean&#39;</span><span class="o">,</span> <span class="n">module</span><span class="o">=</span><span class="s1">&#39;finder-generator&#39;</span><span class="o">,</span> <span class="n">version</span><span class="o">=</span><span class="s1">&#39;<span class='finder-generator-version'>${version}</span>&#39;</span><span class="o">)</span>
 <span class="o">)</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Gradle1">
+      <div role="tabpanel" class="tab-pane" id="Gradle4">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:finder-generator:<span class='finder-generator-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Buildr1">
+      <div role="tabpanel" class="tab-pane" id="Buildr4">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:finder-generator:<span class='finder-generator-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>    </div>
-      <div role="tabpanel" class="tab-pane" id="SBT1">
+      <div role="tabpanel" class="tab-pane" id="SBT4">
 <div class="syntax scala"><div class="highlight"><pre><span></span><span class="n">libraryDependencies</span> <span class="o">+=</span> <span class="s">&quot;org.avaje.ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;finder-generator&quot;</span> <span class="o">%</span> <span class="s">&quot;<span class='finder-generator-version'>${version}</span>&quot;</span>
 </pre></div>
 </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="Leiningen1">
+      <div role="tabpanel" class="tab-pane" id="Leiningen4">
 <div class="syntax xml"><div class="highlight"><pre><span></span>[org.avaje.ebean/finder-generator &quot;<span class='finder-generator-version'>${version}</span>&quot;]
 </pre></div>
 </div>


### PR DESCRIPTION
On
[http://ebean-orm.github.io/docs/query/typesafe.html](http://ebean-orm.github.io/docs/query/typesafe.html)
there are several snippets which show you how to add various dependencies with several build tools. Unfortunately, the anchors are wrong for all but the first dependency (querybean-generator). I think that this has to do with wrong anchors in the following snippets. You can see this, e.g., when you click on the gradle tab for ebean-querybean: What happens is that the tab for querybean-generator switches to gradle, but ebean-querybean stays the same.
My proposed changes should fix that - unfortunately, I was not able to get the website work properly on my local machine, so that I can only hope that it works, but I am rather confident.
