### PR TITLE
Update groupId to "io.ebean"

### DIFF
--- a/releases.html
+++ b/releases.html
@@ -95,7 +95,7 @@
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane active" id="Maven1">
 <div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency&gt;</span>
-  <span class="nt">&lt;groupId&gt;</span>org.avaje.ebean<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>io.ebean<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>ebean<span class="nt">&lt;/artifactId&gt;</span>
   <span class="nt">&lt;version&gt;</span><span class='ebean-version'>${version}</span><span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
@@ -103,33 +103,33 @@
 </div>
       </div>
       <div role="tabpanel" class="tab-pane" id="Ivy1">
-<div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency</span> <span class="na">org=</span><span class="s">&quot;org.avaje.ebean&quot;</span> <span class="na">name=</span><span class="s">&quot;ebean&quot;</span> <span class="na">rev=</span><span class="s">&quot;<span class='ebean-version'>${version}</span>&quot;</span><span class="nt">/&gt;</span>
+<div class="syntax xml"><div class="highlight"><pre><span></span><span class="nt">&lt;dependency</span> <span class="na">org=</span><span class="s">&quot;io.ebean&quot;</span> <span class="na">name=</span><span class="s">&quot;ebean&quot;</span> <span class="na">rev=</span><span class="s">&quot;<span class='ebean-version'>${version}</span>&quot;</span><span class="nt">/&gt;</span>
 </pre></div>
 </div>
       </div>
       <div role="tabpanel" class="tab-pane" id="Grape1">
 <div class="syntax groovy"><div class="highlight"><pre><span></span><span class="nd">@Grapes</span><span class="o">(</span>
-  <span class="nd">@Grab</span><span class="o">(</span><span class="n">group</span><span class="o">=</span><span class="s1">&#39;org.avaje.ebean&#39;</span><span class="o">,</span> <span class="n">module</span><span class="o">=</span><span class="s1">&#39;ebean&#39;</span><span class="o">,</span> <span class="n">version</span><span class="o">=</span><span class="s1">&#39;<span class='ebean-version'>${version}</span>&#39;</span><span class="o">)</span>
+  <span class="nd">@Grab</span><span class="o">(</span><span class="n">group</span><span class="o">=</span><span class="s1">&#39;io.ebean&#39;</span><span class="o">,</span> <span class="n">module</span><span class="o">=</span><span class="s1">&#39;ebean&#39;</span><span class="o">,</span> <span class="n">version</span><span class="o">=</span><span class="s1">&#39;<span class='ebean-version'>${version}</span>&#39;</span><span class="o">)</span>
 <span class="o">)</span>
 </pre></div>
 </div>
       </div>
       <div role="tabpanel" class="tab-pane" id="Gradle1">
-<div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:ebean:<span class='ebean-version'>${version}</span>&#39;</span>
+<div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;io.ebean:ebean:<span class='ebean-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>
       </div>
       <div role="tabpanel" class="tab-pane" id="Buildr1">
-<div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;org.avaje.ebean:ebean:<span class='ebean-version'>${version}</span>&#39;</span>
+<div class="syntax groovy"><div class="highlight"><pre><span></span><span class="s1">&#39;io.ebean:ebean:<span class='ebean-version'>${version}</span>&#39;</span>
 </pre></div>
 </div>    </div>
       <div role="tabpanel" class="tab-pane" id="SBT1">
-<div class="syntax scala"><div class="highlight"><pre><span></span><span class="n">libraryDependencies</span> <span class="o">+=</span> <span class="s">&quot;org.avaje.ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;<span class='ebean-version'>${version}</span>&quot;</span>
+<div class="syntax scala"><div class="highlight"><pre><span></span><span class="n">libraryDependencies</span> <span class="o">+=</span> <span class="s">&quot;io.ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;ebean&quot;</span> <span class="o">%</span> <span class="s">&quot;<span class='ebean-version'>${version}</span>&quot;</span>
 </pre></div>
 </div>
       </div>
       <div role="tabpanel" class="tab-pane" id="Leiningen1">
-<div class="syntax xml"><div class="highlight"><pre><span></span>[org.avaje.ebean/ebean &quot;<span class='ebean-version'>${version}</span>&quot;]
+<div class="syntax xml"><div class="highlight"><pre><span></span>[io.ebean/ebean &quot;<span class='ebean-version'>${version}</span>&quot;]
 </pre></div>
 </div>
       </div>
@@ -140,7 +140,7 @@
 
         <h2>Latest</h2>
         <p>
-          View the latest artifacts for <code>org.avaje.ebean</code> in <a target="_blank" href="http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.avaje.ebean%22">maven central</a>.
+          View the latest artifacts for <code>io.ebean</code> in <a target="_blank" href="http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.ebean%22">maven central</a>.
         </p>
 
         <h3 class="mtm">Older versions</h3>
@@ -151,7 +151,7 @@
 
         <h4 class="mtm">ArtifactId changes</h4>
         <p>
-          In moving to the <code>org.avaje.ebean</code> groupId the artifactId's where changed to follow a simpler
+          In moving to the <code>io.ebean</code> groupId the artifactId's where changed to follow a simpler
           naming convention.
         </p>
 


### PR DESCRIPTION
I see in maven central the groupId changed from org.avaje.ebean to io.ebean